### PR TITLE
Starting credits for players new to the server

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,7 @@ Ban-Time: 12h
 Death-Message: You have died! You are now banned for %bantimeleft%.
 Early-Message: Your ban is not up for another %bantimeleft%.
 Tick-Delay: 15
+Starting-Credits: 0
 Verbose: false
 Death-Classes:
   Donator:

--- a/src/com/mstiles92/hardcoredeathban/HardcoreDeathBanPlugin.java
+++ b/src/com/mstiles92/hardcoredeathban/HardcoreDeathBanPlugin.java
@@ -288,4 +288,12 @@ public class HardcoreDeathBanPlugin extends JavaPlugin {
 		credits.getConfig().set(player.toLowerCase(), credit);
 		credits.save();
 	}
+	
+	public boolean playerHasJoined(String player) {
+		Object o = credits.getConfig().get(player.toLowerCase());
+		if (o != null) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/src/com/mstiles92/hardcoredeathban/events/LoginEvent.java
+++ b/src/com/mstiles92/hardcoredeathban/events/LoginEvent.java
@@ -30,6 +30,13 @@ public class LoginEvent implements Listener {
 					plugin.removeFromBan(e.getName());
 					e.allow();
 				}
+			} else if(!plugin.playerHasJoined(e.getName())) {
+				int startingCredits = plugin.config.getInt("Starting-Credits");
+				plugin.log("New player recieved " + 
+					    Integer.toString(startingCredits) +
+					    " revival credits upon their first login: " + e.getName());
+				plugin.giveCredits(e.getName(), startingCredits);
+				e.allow();
 			} else {
 				e.allow();
 			}


### PR DESCRIPTION
Hey,
First off, thanks for the awesome plugin! I've started using it on my server and it's been great. The only thing I wanted was a way to give new players some leniency when they are just starting out. I created it here in the form of giving new players credits when they join the server for the first time. I figured I would submit the code in case this feature would be something you're interested in. The code should tell it all; I added a check to plugin that determines if credits is null. If it is when they join, set it to the starting credit value. I haven't done any super extensive testing but it seems to be working great, for what it's worth.
Thanks!
